### PR TITLE
Sign Up Modified

### DIFF
--- a/mibiosoft/protocat/templates/sign_up.html
+++ b/mibiosoft/protocat/templates/sign_up.html
@@ -77,7 +77,7 @@ $(document).on('ready', function() {
 				{% csrf_token %}
 				<input type="text" name="username" class="form-control" placeholder="Username"><br>
 				<input type="password" name="password" class="form-control" placeholder="Password"><br>
-				<input type="password" name="email" class="form-control" placeholder="placeholder@website.com"><br>
+				<input type="text" name="email" class="form-control" placeholder="placeholder@website.com"><br>
 				<input type="submit" class="form-control" value="Sign up">
 			</form>
 		</div>


### PR DESCRIPTION
Old sign up page used type 'password' for the email field.

Obviously, this was not very good.

I changed it to 'text'.